### PR TITLE
fix component included in result

### DIFF
--- a/src/main/java/com/slickqa/jupiter/SlickJunitController.java
+++ b/src/main/java/com/slickqa/jupiter/SlickJunitController.java
@@ -340,6 +340,9 @@ public class SlickJunitController {
             result.setProject(projectReference);
             result.setTestrun(testrunReference);
             result.setTestcase(testReference);
+            if(testcase != null && testcase.getComponent() != null) {
+                result.setComponent(testcase.getComponent());
+            }
             result.setStatus("NO_RESULT");
             result.setReason("not run yet...");
             result.setRecorded(new Date());

--- a/src/test/java/com/slickqa/jupiter/e2e/tests/MetaDataAccuracyTests.java
+++ b/src/test/java/com/slickqa/jupiter/e2e/tests/MetaDataAccuracyTests.java
@@ -73,8 +73,7 @@ public class MetaDataAccuracyTests {
         assertNotNull(result, "The result from slick should not be null");
         Testcase slickTestcase = util.slick.testcase(result.getTestcase().getTestcaseId()).get();
         SlickMetaData info = test.getDeclaredAnnotation(SlickMetaData.class);
-        // TODO: fix component on result and re-enable assert
-        // assertEquals(info.component(), result.getComponent().getName(), "Component of result should come from SlickMetaData");
+        assertEquals(info.component(), result.getComponent().getName(), "Component of result should come from SlickMetaData");
         assertEquals(info.component(), slickTestcase.getComponent().getName(), "Component of test case should have come from SlickMetaData");
     }
 


### PR DESCRIPTION
Currently result's component is always null.  This makes it so that it should be the same as the testcase.