### PR TITLE
Title and steps are now optional

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     //testCompile group: 'junit', name: 'junit', version: '4.12'
     compile 'org.junit.jupiter:junit-jupiter-api:5.4.2'
     compile 'org.junit.jupiter:junit-jupiter-engine:5.4.2'
+    compile 'org.junit.jupiter:junit-jupiter-params:5.4.2'
     compile 'org.junit.platform:junit-platform-launcher:1.4.2'
     compile 'com.slickqa:slickqa-java-client:1.0.3-6'
     testCompile 'org.mongodb:bson:3.10.2'

--- a/src/main/java/com/slickqa/jupiter/BeforeEachExtension.java
+++ b/src/main/java/com/slickqa/jupiter/BeforeEachExtension.java
@@ -39,7 +39,7 @@ public class BeforeEachExtension implements BeforeEachCallback {
             if (context.getTestMethod().isPresent()) {
                 Method testMethod = context.getTestMethod().get();
                 //System.out.println(MessageFormat.format("Test found: {0}", testMethod.getName()));
-                Result result = controller.getOrCreateResultFor(testMethod, context.getUniqueId());
+                Result result = controller.getOrCreateResultFor(testMethod, context.getUniqueId(), context.getDisplayName());
                 Result update = new Result();
                 update.setStarted(new Date());
                 update.setReason("");

--- a/src/main/java/com/slickqa/jupiter/SlickJunitController.java
+++ b/src/main/java/com/slickqa/jupiter/SlickJunitController.java
@@ -180,7 +180,7 @@ public class SlickJunitController {
         return automationId;
     }
 
-    public void addResultFor(Method testDescription, String uniqueID) throws SlickError {
+    public void addResultFor(Method testDescription, String uniqueID, String displayName) throws SlickError {
         if (isUsingSlick()) {
             SlickMetaData metaData = testDescription.getAnnotation(SlickMetaData.class);
             boolean hasMetaData = metaData != null;
@@ -223,11 +223,7 @@ public class SlickJunitController {
             if (hasMetaData && !"".equals(metaData.title())) {
                 testcase.setName(metaData.title());
             } else {
-                if (testDescription.isAnnotationPresent(DisplayName.class)) {
-                    testcase.setName(testDescription.getAnnotation(DisplayName.class).value());
-                } else {
-                    testcase.setName(testDescription.getName());
-                }
+                testcase.setName(displayName);
             }
             testcase.setProject(projectReference);
             if (newTestcase) {
@@ -362,12 +358,12 @@ public class SlickJunitController {
         return results.getOrDefault(automationId, null);
     }
 
-    public Result getOrCreateResultFor(Method testDescription, String uniqueID) {
+    public Result getOrCreateResultFor(Method testDescription, String uniqueID, String displayName) {
         if(isUsingSlick()) {
             Result result = getResultFor(uniqueID);
             if(result == null) {
                 try {
-                    addResultFor(testDescription, uniqueID);
+                    addResultFor(testDescription, uniqueID, displayName);
                     return getResultFor(uniqueID);
                 } catch (SlickError e) {
                     e.printStackTrace();

--- a/src/main/java/com/slickqa/jupiter/SlickJunitController.java
+++ b/src/main/java/com/slickqa/jupiter/SlickJunitController.java
@@ -219,7 +219,8 @@ public class SlickJunitController {
                 testcase = new Testcase();
                 newTestcase = true;
             }
-            if (hasMetaData) {
+
+            if (hasMetaData && !"".equals(metaData.title())) {
                 testcase.setName(metaData.title());
             } else {
                 if (testDescription.isAnnotationPresent(DisplayName.class)) {

--- a/src/main/java/com/slickqa/jupiter/SlickTestExecutionListener.java
+++ b/src/main/java/com/slickqa/jupiter/SlickTestExecutionListener.java
@@ -54,7 +54,7 @@ public class SlickTestExecutionListener implements TestExecutionListener {
                                 try {
                                     Method testMethod = clazz.getMethod(methodName);
                                     if (!testMethod.isAnnotationPresent(Disabled.class)) {
-                                        controller.getOrCreateResultFor(testMethod, automationID);
+                                        controller.getOrCreateResultFor(testMethod, automationID, h.getDisplayName());
                                     }
                                 } catch (NoSuchMethodException e) {
                                     // nada

--- a/src/main/java/com/slickqa/jupiter/annotations/SlickMetaData.java
+++ b/src/main/java/com/slickqa/jupiter/annotations/SlickMetaData.java
@@ -12,15 +12,15 @@ import java.lang.annotation.Target;
 @Retention( RetentionPolicy.RUNTIME )
 @Target( ElementType.METHOD )
 public @interface SlickMetaData {
-    String value = "";
+    String empty = "";
 
-    String title();
-    String purpose() default value;
-    String component() default value;
-    String feature() default value;
-    String automationId() default value;
-    String automationKey() default value;
-    Step[] steps();
-    String triageNote() default value;
-    String author() default value;
+    String title() default empty;
+    String purpose() default empty;
+    String component() default empty;
+    String feature() default empty;
+    String automationId() default empty;
+    String automationKey() default empty;
+    Step[] steps() default {};
+    String triageNote() default empty;
+    String author() default empty;
 }

--- a/src/test/java/com/slickqa/jupiter/e2e/example/MetaDataTests.java
+++ b/src/test/java/com/slickqa/jupiter/e2e/example/MetaDataTests.java
@@ -5,7 +5,10 @@ import com.slickqa.jupiter.annotations.SlickMetaData;
 import com.slickqa.jupiter.annotations.Step;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MetaDataTests extends SlickBaseTest {
@@ -60,6 +63,11 @@ public class MetaDataTests extends SlickBaseTest {
     )
     public void testTriageNote() {
         assertTrue(false, "This will cause a triage note to be applied");
+    }
+
+    @ParameterizedTest(name="Test {0}")
+    @ValueSource(strings={"Yomama"})
+    public void testTemplatedName(String parameter) {
     }
 
 }

--- a/src/test/java/com/slickqa/jupiter/e2e/example/MetaDataTests.java
+++ b/src/test/java/com/slickqa/jupiter/e2e/example/MetaDataTests.java
@@ -42,6 +42,12 @@ public class MetaDataTests extends SlickBaseTest {
     }
 
     @Test
+    @SlickMetaData()
+    @DisplayName("Name from DisplayName")
+    public void testDisplayNameEmptyMetadataName() {
+    }
+
+    @Test
     public void testMethodNameOnly() {
     }
 

--- a/src/test/java/com/slickqa/jupiter/e2e/tests/MetaDataAccuracyTests.java
+++ b/src/test/java/com/slickqa/jupiter/e2e/tests/MetaDataAccuracyTests.java
@@ -57,6 +57,18 @@ public class MetaDataAccuracyTests {
     }
 
     @Test
+    @DisplayName("Test name comes from DisplayName when SlickMetaData title is empty.")
+    public void testNameComesFromDisplayNameWhenSlickMetaDataIsEmpty() throws Exception {
+        Method test = MetaDataTests.class.getMethod("testDisplayNameEmptyMetadataName");
+        SlickMetaData info = test.getDeclaredAnnotation(SlickMetaData.class);
+        assertEquals("", info.title(), "The title in SlickMetaData should be empty (default).  If this is not true then somebody messed up the test.");
+        Result result = util.runTestMethod(test);
+        assertNotNull(result, "The result from slick should not be null");
+        DisplayName displayName = test.getDeclaredAnnotation(DisplayName.class);
+        assertEquals(displayName.value(), result.getTestcase().getName(), "name of the test should come from DisplayName as SlickMetaData's title is empty");
+    }
+
+    @Test
     @DisplayName("Test name comes from method name when no annotation is present")
     public void testNameComesFromMethodNameWhenNoAnnotationIsPresent() throws Exception {
         Method test = MetaDataTests.class.getMethod("testMethodNameOnly");

--- a/src/test/java/com/slickqa/jupiter/e2e/tests/MetaDataAccuracyTests.java
+++ b/src/test/java/com/slickqa/jupiter/e2e/tests/MetaDataAccuracyTests.java
@@ -74,7 +74,16 @@ public class MetaDataAccuracyTests {
         Method test = MetaDataTests.class.getMethod("testMethodNameOnly");
         Result result = util.runTestMethod(test);
         assertNotNull(result, "The result from slick should not be null");
-        assertEquals(test.getName(), result.getTestcase().getName(), "name of test should come from the method name");
+        assertEquals(test.getName() + "()", result.getTestcase().getName(), "name of test should come from the method name");
+    }
+
+    @Test
+    @DisplayName("Test that the templated name is given to slick")
+    public void testTemplatedName() throws Exception {
+        Method test = MetaDataTests.class.getMethod("testTemplatedName", String.class);
+        Result result = util.runTestMethod(test);
+        assertNotNull(result, "The result from slick should not be null");
+        assertEquals("Test Yomama", result.getTestcase().getName(), "name should be the templated name.");
     }
 
     @Test


### PR DESCRIPTION
In order to make it so that we can get templated test names from data-driven tests with jupiter, we need title in SlickMetaData to be optional, and I went ahead and made steps optional.

If title is empty (the default) and DisplayName is present then DisplayName's name will be used.