### PR TITLE
Adding the text file that allows for automatic extension loading

### DIFF
--- a/src/main/resources/META-INF/services/org/junit/jupiter/api/extension/Extension
+++ b/src/main/resources/META-INF/services/org/junit/jupiter/api/extension/Extension
@@ -1,0 +1,3 @@
+com.slickqa.jupiter.SlickTestWatcher
+com.slickqa.jupiter.BeforeEachExtension
+com.slickqa.jupiter.BeforeTestExecutionExtension


### PR DESCRIPTION
If someone turns on automatic loading of junit jupiter extensions, our extensions will auto load (without having to be applied directly to the class).